### PR TITLE
Revert "ci: Lock to node alpine 20 in CI since dart-sass is no compatible yet with node 21"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,7 +34,7 @@ jobs:
             - run: php bin/phpunit
     yarn:
         runs-on: ubuntu-latest
-        container: node:20-alpine
+        container: node:alpine
         steps:
             - uses: actions/checkout@v2
             - uses: actions/cache@v1


### PR DESCRIPTION
This reverts commit f8e8f69d79bfadd2e53ca992ae0ffa24323186d3.